### PR TITLE
feature/fix dependabot cve, rename cruft job and update versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - update workflow triggers and schedules
+- rename cookiecutter workflow main job to `cruft`
+- update poetry and pre-commit dependencies
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- do not run cve on Dependabot push events
 
 ### Security

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -13,7 +13,7 @@ env:
   PIP_PREFER_BINARY: on
 
 jobs:
-  lint:
+  cruft:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
@@ -2,6 +2,11 @@ name: CVE Scan
 
 on:
   push:
+    # Workflows triggered by Dependabot on the "push" event run with read-only access.
+    # Uploading Code Scanning results requires write access. We therefore only use the
+    # "pull_request" trigger for Dependabot branches.
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.2.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -12,12 +12,12 @@ packages = [{ include = "mex" }]
 python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.12.1"
+black = "^24.1.1"
 ipdb = "^0.13.13"
 mypy = "^1.8.0"
-pytest = "^7.4.4"
+pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
-ruff = "^0.1.13"
+ruff = "^0.2.0"
 sphinx = "^7.2.6"
 
 [tool.poetry.scripts]
@@ -102,5 +102,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["poetry-core>=1.8.1"]
+requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# PR Context
- fixes https://github.com/robert-koch-institut/mex-common/actions/runs/7787019895/job/21233174583
- dependabot should only run on `pull_request` trigger, not on `push`

- the reason that the cookiecutter job was called `lint` before was just a copy&paste error 🍝 

# Changes
- rename cookiecutter workflow main job to `cruft`
- update poetry and pre-commit dependencies

# Fixed
- do not run cve on Dependabot push events