### PR TITLE
feature/fine-tune linting config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - create CHANGELOG.md
 - configure dependabot updates for github-actions
+- add EOF, WS and BOM githooks
 - add A, B, PERF and UP ruff linter rule sets
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - create CHANGELOG.md
 - configure dependabot updates for github-actions
+- add A, B, PERF and UP ruff linter rule sets
 
 ### Changes
 

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
         exclude: .cruft.json
       - id: check-yaml
         name: yaml
+      - id: end-of-file-fixer
+        name: eof
+      - id: trailing-whitespace
+        name: whitespaces
+      - id: fix-byte-order-marker
+        name: byte-order
   - repo: https://github.com/python-poetry/poetry
     rev: 1.7.1
     hooks:

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -12,12 +12,12 @@ packages = [{ include = "mex" }]
 python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.1.1"
+black = "^24.2.0"
 ipdb = "^0.13.13"
 mypy = "^1.8.0"
 pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
-ruff = "^0.2.0"
+ruff = "^0.2.1"
 sphinx = "^7.2.6"
 
 [tool.poetry.scripts]
@@ -53,6 +53,9 @@ markers = "integration: mark a test as integration test"
 
 [tool.ruff]
 fix = true
+show-fixes = true
+
+[tool.ruff.lint]
 ignore = [
     "D100",   # Allow missing module docstring for brevity
     "D104",   # Allow missing package docstring for brevity
@@ -67,24 +70,26 @@ ignore = [
     "RUF012", # Allow mutable class attributes (pydantic compat)
 ]
 select = [
-    "C90", # McCabe complexity checker
-    "D",   # Python docstring style checker
-    "E",   # Python code style errors
-    "ERA", # Commented-out code detector
-    "F",   # Pyflakes passive python checker
-    "I",   # Isort import utility
-    "N",   # Pep8 naming conventions
-    "RET", # Flake8 return statement checker
-    "RUF", # Ruff-specific rules
-    "S",   # Bandit automated security testing
-    "T10", # Flake8 debug statement checker
-    "T20", # Flake8 print statement checker
-    "W",   # Python code style warnings
+    "A",    # Flake8 builtin shaddow
+    "B",    # BugBear bug and issue finder
+    "C90",  # McCabe complexity checker
+    "D",    # Python docstring style checker
+    "E",    # Python code style errors
+    "ERA",  # Commented-out code detector
+    "F",    # Pyflakes passive python checker
+    "I",    # Isort import utility
+    "N",    # Pep8 naming conventions
+    "PERF", # Lint performance anti-patterns
+    "RET",  # Flake8 return statement checker
+    "RUF",  # Ruff-specific rules
+    "S",    # Bandit automated security testing
+    "T10",  # Flake8 debug statement checker
+    "T20",  # Flake8 print statement checker
+    "UP",   # PyUpgrade syntax recommender
+    "W",    # Python code style warnings
 ]
-show-fixes = true
-target-version = "py311"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**" = [
     "D101", # Allow missing docstring in public class for tests
     "D102", # Allow missing docstring in public method for tests
@@ -95,10 +100,10 @@ target-version = "py311"
     "S101", # Allow use of `assert` in tests
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["mex", "tests"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [build-system]

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.15.0
 poetry==1.7.1
-pre-commit==3.6.0
+pre-commit==3.6.1
 wheel==0.42.0


### PR DESCRIPTION
# PR Context
- ruff 0.2.1 needed a new config structure in the toml
- we had some extra hooks in mex-model and mex-assets that were missing in the other repos, so i added them here in the template as well
- i found a few more ruff linters that could be helpful for our setup

# Added
<!-- New features and interfaces -->
- add [EOF](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#end-of-file-fixer), [WS](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace) and [BOM](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#fix-byte-order-marker) githooks
- add [A](https://docs.astral.sh/ruff/rules/#flake8-builtins-a), [B](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b), [PERF](https://docs.astral.sh/ruff/rules/#perflint-perf) and [UP](https://docs.astral.sh/ruff/rules/#pyupgrade-up) ruff linter rule sets

# Changes
<!-- Changes in existing functionality -->
- update poetry and pre-commit dependencies
