### PR TITLE
feature/Configure pytest-random execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - configure dependabot updates for github-actions
 - add EOF, WS and BOM githooks
 - add A, B, PERF and UP ruff linter rule sets
+- add pytest-random as dev dependency
+- activate random pytest order by default
 
 ### Changes
 

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -17,6 +17,7 @@ ipdb = "^0.13.13"
 mypy = "^1.8.0"
 pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
+pytest-random-order = "^1.1.1"
 ruff = "^0.2.1"
 sphinx = "^7.2.6"
 
@@ -48,6 +49,7 @@ addopts = [
     "--cov-fail-under=95",
     "--cov-branch",
     "--pdbcls=IPython.terminal.debugger:TerminalPdb",
+    "--random-order-bucket=global",
 ]
 markers = "integration: mark a test as integration test"
 


### PR DESCRIPTION
# Added
<!-- New features and interfaces -->
- add `pytest-random` as dev dependency
- activate random pytest order by default
