### PR TITLE
Feature/automate cruft updates and other ci improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     allow:
       - dependency-type: "all"
+    assignees:
+      - ${{secrets.MEX_BOT_USER}}
     directory: "/"
     labels:
       - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     allow:
       - dependency-type: "all"
     directory: "/"
+    labels:
+      - "dependabot"
     open-pull-requests-limit: 1
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/workflows/open-code.yml
+++ b/.github/workflows/open-code.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'main'
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename cookiecutter workflow main job to `cruft`
 - update poetry and pre-commit dependencies
 - always tag dependabot prs as `dependabot`
+- narrow pull-request workflow trigger to reduce duplicate runs
+- update github actions dependencies
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add A, B, PERF and UP ruff linter rule sets
 - add pytest-random as dev dependency
 - activate random pytest order by default
+- add bot user as assignee to dependabot prs
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add pytest-random as dev dependency
 - activate random pytest order by default
 - add bot user as assignee to dependabot prs
-- add pr author as assignee for user prs
+- add workflow to set pr author as assignee for user prs
+- let cookiecutter workflow create PRs to run cruft update
 
 ### Changes
 
@@ -26,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - always tag dependabot prs as `dependabot`
 - narrow pull-request workflow trigger to reduce duplicate runs
 - update github actions dependencies
-- let cookiecutter workflow create PRs to run cruft update
+- update pre-commit/requirements.txt/poetry dependencies
+- set github actions dependabot to weekly
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - always tag dependabot prs as `dependabot`
 - narrow pull-request workflow trigger to reduce duplicate runs
 - update github actions dependencies
+- let cookiecutter workflow create PRs to run cruft update
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add pytest-random as dev dependency
 - activate random pytest order by default
 - add bot user as assignee to dependabot prs
+- add pr author as assignee for user prs
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update workflow triggers and schedules
 - rename cookiecutter workflow main job to `cruft`
 - update poetry and pre-commit dependencies
+- always tag dependabot prs as `dependabot`
 
 ### Deprecated
 

--- a/mex-{{ cookiecutter.project_name }}/.github/dependabot.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/dependabot.yml
@@ -4,13 +4,17 @@ updates:
     allow:
       - dependency-type: "all"
     directory: "/"
+    labels:
+      - "dependabot"
     open-pull-requests-limit: 1
     schedule:
-      interval: "monthly"
+      interval: "weekly"
   - package-ecosystem: "pip"
     allow:
       - dependency-type: "all"
     directory: "/"
+    labels:
+      - "dependabot"
     open-pull-requests-limit: 1
     schedule:
       interval: "daily"

--- a/mex-{{ cookiecutter.project_name }}/.github/dependabot.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     allow:
       - dependency-type: "all"
+    assignees:
+      - ${{secrets.MEX_BOT_USER}}
     directory: "/"
     labels:
       - "dependabot"
@@ -12,6 +14,8 @@ updates:
   - package-ecosystem: "pip"
     allow:
       - dependency-type: "all"
+    assignees:
+      - ${{secrets.MEX_BOT_USER}}
     directory: "/"
     labels:
       - "dependabot"

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -2,11 +2,8 @@ name: Cookiecutter
 
 on:
   push:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
+    branches: ["main"]
+    tags: ["**"]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -24,7 +21,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -44,5 +41,37 @@ jobs:
       - name: Install requirements
         run: make setup
 
-      - name: Check template
-        run: cruft check
+      - name: Update template
+        continue-on-error: true
+        env:
+          {% raw %}GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        run: |
+          {% raw %}if cruft check; then
+            echo template is up to date
+            exit 0
+          fi
+          if [[ $(gh pr list --label cruft | wc -c) -ne 0 ]]; then
+            echo already seeing pull request
+            exit 0
+          fi
+          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
+          template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
+          git checkout main
+          git checkout -b cruft/cookiecutter-template-${template_ref}
+          cruft update --skip-apply-ask
+          printf '# Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
+          if [[ $(git status --porcelain | wc -c) -ne 0 ]]; then
+            printf '\n# Conflicts\n' >> .cruft-pr-body
+          fi
+          git status --porcelain | grep .rej | awk '{print $2;}' | while read -r line ; do
+            printf '\n```' >> .cruft-pr-body
+            cat ${line} >> .cruft-pr-body
+            printf '```\n' >> .cruft-pr-body
+          done
+          git add --all --verbose
+          git config --global user.email ${{ vars.MEX_BOT_EMAIL }}
+          git config --global user.name ${{ vars.MEX_BOT_USER }}
+          git commit --message "Bump cookiecutter template to $template_ref" --verbose
+          git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
+          gh pr create --title "Bump cookiecutter template to $template_ref" --body-file .cruft-pr-body --label cruft --assignee ${{ vars.MEX_BOT_USER }}
+          exit 1{% endraw %}

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -3,6 +3,10 @@ name: Cookiecutter
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -18,12 +22,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -33,7 +37,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
@@ -8,6 +8,10 @@ on:
     branches-ignore:
       - 'dependabot/**'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -18,12 +22,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Cache trivy
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-trivy
         with:

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/docker.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/docker.yml
@@ -11,4 +11,4 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.1.3
+        uses: GlueOps/github-actions-build-push-containers@v0.3

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/documentation.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/documentation.yml
@@ -25,12 +25,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -40,7 +40,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Cache poetry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-poetry
         with:
@@ -50,12 +50,12 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
       - name: Setup pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Install requirements
         run: make install
@@ -64,7 +64,7 @@ jobs:
         run: make docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/dist
 
@@ -77,4 +77,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/linting.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/linting.yml
@@ -3,6 +3,10 @@ name: Linting
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
 
 env:
@@ -16,12 +20,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -31,7 +35,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Cache poetry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-poetry
         with:
@@ -41,7 +45,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/open-code.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/open-code.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'main'
           fetch-depth: 0

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/reviewing.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/reviewing.yml
@@ -1,0 +1,26 @@
+name: Review
+
+on:
+  pull_request:
+    types:
+      - opened
+  workflow_dispatch:
+
+jobs:
+  assignee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      {% raw %}github.event.pull_request.user.login != ${{ vars.MEX_BOT_USER }} &&{% endraw %}
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Add assignee
+        env:
+          {% raw %}GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        run: |
+          {% raw %}if [[ -z "${{ github.event.pull_request.assignee.login }}" ]]; then
+            echo assigning to ${{ github.event.pull_request.user.login }}
+            gh pr edit ${{ github.event.pull_request.html_url }} --add-assignee ${{ github.event.pull_request.user.login }}
+          else
+            echo already assigned
+          fi{% endraw %}

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/testing.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/testing.yml
@@ -3,6 +3,10 @@ name: Testing
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
 
 env:
@@ -16,12 +20,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -31,7 +35,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Cache poetry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-poetry
         with:
@@ -41,7 +45,7 @@ jobs:
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/mex-{{ cookiecutter.project_name }}/.gitignore
+++ b/mex-{{ cookiecutter.project_name }}/.gitignore
@@ -100,6 +100,10 @@ dmypy.json
 # ruff
 .ruff_cache
 
+# cruft
+.cruft-pr-body
+*.rej
+
 # PyCharm
 .idea/
 .idea_modules/

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.2.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -27,7 +27,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.7.1
+    rev: 1.8.1
     hooks:
       - id: poetry-check
         name: poetry

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -15,10 +15,10 @@ python = "^3.11"
 black = "^24.2.0"
 ipdb = "^0.13.13"
 mypy = "^1.8.0"
-pytest = "^8.0.0"
+pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
 pytest-random-order = "^1.1.1"
-ruff = "^0.2.1"
+ruff = "^0.2.2"
 sphinx = "^7.2.6"
 
 [tool.poetry.scripts]

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.15.0
-poetry==1.7.1
-pre-commit==3.6.1
+poetry==1.8.1
+pre-commit==3.6.2
 wheel==0.42.0


### PR DESCRIPTION
# Added
- add workflow to set pr author as assignee for user prs
- let cookiecutter workflow create PRs to run cruft update

# Changes
- always tag dependabot prs as `dependabot`
- narrow pull-request workflow trigger to reduce duplicate runs
- update github actions dependencies
- update pre-commit/requirements.txt/poetry dependencies
- set github actions dependabot to weekly
