### PR TITLE
hotfix/fix docker build

### DIFF
--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/docker.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/docker.yml
@@ -11,4 +11,4 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.4
+        uses: GlueOps/github-actions-build-push-containers@v0.4.2


### PR DESCRIPTION
# PR Context
<!-- Additional info for the reviewer -->

Docker build is currently broken, as partial version numbers for github actions do not work (see [here](https://github.com/robert-koch-institut/mex-drop/actions/runs/9265211033/job/25486780307)). I therefore replaced the version with the full version.

# Fixed

- docker build action: full version number of action dependency is required
