### PR TITLE
allow subprocesses without shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - configure ruff formatting and pre-commit hook
 - added RKI postal address to README files
+- allow subprocesses without shell
 
 ### Changes
 

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -90,7 +90,7 @@ ignore = [
     "N805",   # Allow first argument of a method to be non-self (pydantic compat)
     "N815",   # Allow mixedCase variables in class scope (model compat)
     "RUF012", # Allow mutable class attributes (pydantic compat)
-    "S603",   # Allow initiating subclasses without a shell
+    "S603",   # Allow initiating subprocesses without a shell
 ]
 select = [
     "A",    # Flake8 builtin shaddow

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -90,6 +90,7 @@ ignore = [
     "N805",   # Allow first argument of a method to be non-self (pydantic compat)
     "N815",   # Allow mixedCase variables in class scope (model compat)
     "RUF012", # Allow mutable class attributes (pydantic compat)
+    "S603",   # Allow initiating subclasses without a shell
 ]
 select = [
     "A",    # Flake8 builtin shaddow


### PR DESCRIPTION
# PR Context
see mex-assets:mex\ops\mapping\validate.py line 46

# Added
- allow subprocesses without shell

