### PR TITLE
feature/template maint

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.2
+        uses: renovatebot/github-action@v40.3.3
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-template"

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.1
+        uses: renovatebot/github-action@v40.3.2
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-template"

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.3
+        uses: renovatebot/github-action@v40.3.4
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-template"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - prevent duplicate github pipelines for test, cve and lint
 - build and push containers without glueops
 - loosen dependencies in pyproject.toml
+- use all ruff linter rules (with some opt-outs)
+- install mex-release from pypi rather than github
+- constrain dev-dependencies only to major/minor versions, to limit renovate noise
+- title-case readme headings for a more professional look
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cookiecutter template for MEx python projects.
 
 [![open-code](https://github.com/robert-koch-institut/mex-template/actions/workflows/open-code.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-template)
 
-## project
+## Project
 
 The Metadata Exchange (MEx) project is committed to improve the retrieval of RKI
 research data and projects. How? By focusing on metadata: instead of providing the
@@ -34,26 +34,27 @@ data Findable, Accessible, Interoperable and Reusable.
 **Contact** \
 For more information, please feel free to email us at [mex@rki.de](mailto:mex@rki.de).
 
-### Publisher of this document
+### Publisher
+
 **Robert Koch-Institut** \
 Nordufer 20 \
 13353 Berlin \
 Germany
 
-## package
+## Package
 
 The `mex-template` is a [cookiecutter](https://www.cookiecutter.io/) template to make
 starting a new python project easier and to keep boilerplate files harmonized using
 [cruft](https://cruft.github.io/cruft/).
 
-## license
+## License
 
 This package is licensed under the [MIT license](/LICENSE). All other software
 components of the MEx project are open-sourced under the same license as well.
 
-## usage
+## Usage
 
-### installation
+### Installation
 
 - on unix, consider using pyenv https://github.com/pyenv/pyenv
   - get pyenv `curl https://pyenv.run | bash`
@@ -66,16 +67,14 @@ components of the MEx project are open-sourced under the same license as well.
   - switch version `pyenv global 3.11`
   - run `pip install cruft`
 
-## usage
-
-### new project
+### Create new
 
 - starting a new project using this template is easy
 - go to your home / code folder
 - run `cruft create https://github.com/robert-koch-institut/mex-template`
 - fill in the prompted values
 
-### update existing
+### Update existing
 
 - there are two tools to help you update the boilerplate of existing projects
 - go to your local checkout of a project using this template

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.1
+        uses: renovatebot/github-action@v40.3.2
         env:
           RENOVATE_GIT_PRIVATE_KEY: {% raw %}${{ secrets.GPG_SIGNING_KEY }}{% endraw %}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-{{ cookiecutter.project_name }}"

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.2
+        uses: renovatebot/github-action@v40.3.3
         env:
           RENOVATE_GIT_PRIVATE_KEY: {% raw %}${{ secrets.GPG_SIGNING_KEY }}{% endraw %}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-{{ cookiecutter.project_name }}"

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.3
+        uses: renovatebot/github-action@v40.3.4
         env:
           RENOVATE_GIT_PRIVATE_KEY: {% raw %}${{ secrets.GPG_SIGNING_KEY }}{% endraw %}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-{{ cookiecutter.project_name }}"

--- a/mex-{{ cookiecutter.project_name }}/README.md
+++ b/mex-{{ cookiecutter.project_name }}/README.md
@@ -9,7 +9,7 @@
 [![open-code](https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/actions/workflows/open-code.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-{{ cookiecutter.project_name }})
 [![testing](https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/actions/workflows/testing.yml/badge.svg)](https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/actions/workflows/testing.yml)
 
-## project
+## Project
 
 The Metadata Exchange (MEx) project is committed to improve the retrieval of RKI
 research data and projects. How? By focusing on metadata: instead of providing the
@@ -39,24 +39,25 @@ data Findable, Accessible, Interoperable and Reusable.
 **Contact** \
 For more information, please feel free to email us at [mex@rki.de](mailto:mex@rki.de).
 
-### Publisher of this document
+### Publisher
+
 **Robert Koch-Institut** \
 Nordufer 20 \
 13353 Berlin \
 Germany
 
-## package
+## Package
 
 {{ cookiecutter.long_summary|wordwrap(88, break_long_words=False, break_on_hyphens=False) }}
 
-## license
+## License
 
 This package is licensed under the [MIT license](/LICENSE). All other software
 components of the MEx project are open-sourced under the same license as well.
 
-## development
+## Development
 
-### installation
+### Installation
 
 - on unix, consider using pyenv https://github.com/pyenv/pyenv
   - get pyenv `curl https://pyenv.run | bash`
@@ -69,13 +70,13 @@ components of the MEx project are open-sourced under the same license as well.
   - switch version `pyenv global 3.11`
   - run `.\mex.bat install`
 
-### linting and testing
+### Linting and testing
 
 - run all linters with `pdm lint`
 - run only unit tests with `pdm unit`
 - run unit and integration tests with `pdm test`
 
-### updating dependencies
+### Updating dependencies
 
 - update boilerplate files with `cruft update`
 - update global requirements in `requirements.txt` manually
@@ -83,18 +84,18 @@ components of the MEx project are open-sourced under the same license as well.
 - update package dependencies using `pdm update-all`
 - update github actions in `.github/workflows/*.yml` manually
 
-### creating release
+### Creating release
 
 - run `pdm release RULE` to release a new version where RULE determines which part of
   the version to update and is one of `major`, `minor`, `patch`.
 
-### container workflow
+### Container workflow
 
 - build image with `make image`
 - run directly using docker `make run`
 - start with docker compose `make start`
 
-## commands
+## Commands
 
 - run `pdm run {command} --help` to print instructions
 - run `pdm run {command} --debug` for interactive debugging

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -79,47 +79,53 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 ignore = [
-    "D100",   # Allow missing module docstring for brevity
-    "D104",   # Allow missing package docstring for brevity
-    "D203",   # Disallow blank line before class docstring (inverse of D211)
-    "D213",   # Disallow multi-line docstring starting at second line (inverse of D212)
-    "D406",   # Allow section name ending with newline (google style compat)
-    "D407",   # Allow missing dashed underline after section (google style compat)
-    "D413",   # Allow missing blank line after last section (google style compat)
-    "N805",   # Allow first argument of a method to be non-self (pydantic compat)
-    "N815",   # Allow mixedCase variables in class scope (model compat)
-    "RUF012", # Allow mutable class attributes (pydantic compat)
+    "AIR",     # Disable airflow specific rules (we are not using airflow)
+    "ANN",     # Disable all annotations checks (handled by mypy)
+    "COM",     # Disable flake8-commas checks (let ruff format handle that)
+    "CPY",     # Disable copyright notice checks (we have LICENSE files)
+    "D100",    # Allow missing module docstring (for brevity and speed)
+    "D104",    # Allow missing package docstring (for brevity and speed)
+    "D203",    # Disallow blank line before class docstring (inverse of D211)
+    "D213",    # Disallow multi-line docstring starting at second line (inverse of D212)
+    "D406",    # Allow section name ending with newline (google style compat)
+    "D407",    # Allow missing dashed underline after section (google style compat)
+    "D413",    # Allow missing blank line after last section (google style compat)
+    "DJ",      # Disable django specific checks (we are not using django)
+    "FBT",     # Disable boolean type hint checks (for more flexibility)
+    "FIX",     # Allow committing with open TODOs (don't punish committers)
+    "N805",    # Allow first argument of a method to be non-self (pydantic compat)
+    "N815",    # Allow mixedCase variables in class scope (model compat)
+    "PTH123",  # Allow using builtin open method (simpler than pathlib)
+    "RUF012",  # Allow mutable class attributes (pydantic compat)
+    "SIM108",  # Allow explicit if-else instead of ternary (easier to read)
+    "TD003",   # Allow TODOs without ticket link (don't punish TODO writers)
+    "TRY003",  # Allow long exception message at the raise site (for pydantic)
 ]
-select = [
-    "A",    # Flake8 builtin shaddow
-    "B",    # BugBear bug and issue finder
-    "C90",  # McCabe complexity checker
-    "D",    # Python docstring style checker
-    "E",    # Python code style errors
-    "ERA",  # Commented-out code detector
-    "F",    # Pyflakes passive python checker
-    "I",    # Isort import utility
-    "N",    # Pep8 naming conventions
-    "PERF", # Lint performance anti-patterns
-    "RET",  # Flake8 return statement checker
-    "RUF",  # Ruff-specific rules
-    "S",    # Bandit automated security testing
-    "T10",  # Flake8 debug statement checker
-    "T20",  # Flake8 print statement checker
-    "UP",   # PyUpgrade syntax recommender
-    "W",    # Python code style warnings
-]
+select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = [
-    "D101", # Allow missing docstring in public class for tests
-    "D102", # Allow missing docstring in public method for tests
-    "D103", # Allow missing docstring in public function for tests
-    "D107", # Allow missing docstring in `__init__` for tests
-    "E501", # Allow line too long in tests
-    "N807", # Allow mocking `__init__` for tests
-    "S101", # Allow use of `assert` in tests
+"docs/**" = [
+    "INP001",   # Docs do not need to be a package
 ]
+"tests/**" = [
+    "ARG005",   # Allow unused lambda arguments for mocking
+    "D101",     # Allow missing docstring in public class
+    "D102",     # Allow missing docstring in public method
+    "D103",     # Allow missing docstring in public function
+    "D107",     # Allow missing docstring in `__init__`
+    "E501",     # Allow longer lines with test data
+    "ISC",      # Allow implicitly concatenated strings
+    "N807",     # Allow mocking `__init__`
+    "PLR0915",  # Allow functions with many statements
+    "PLR2004",  # Allow comparing with static values
+    "PT004",    # Allow public fixtures without returns
+    "PT013",    # Allow more flexible pytest imports
+    "S101",     # Allow use of `assert` in tests
+    "SLF",      # Allow private member access
+]
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+"reflex" = "rx"
 
 [tool.ruff.lint.isort]
 known-first-party = ["mex", "tests"]

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -93,6 +93,7 @@ ignore = [
     "DJ",      # Disable django specific checks (we are not using django)
     "FBT",     # Disable boolean type hint checks (for more flexibility)
     "FIX",     # Allow committing with open TODOs (don't punish committers)
+    "ISC001",  # Disable checks for implicitly concatenated strings (formatter compat)
     "N805",    # Allow first argument of a method to be non-self (pydantic compat)
     "N815",    # Allow mixedCase variables in class scope (model compat)
     "PTH123",  # Allow using builtin open method (simpler than pathlib)

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -105,7 +105,10 @@ select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/**" = [
-    "INP001",   # Docs do not need to be a package
+    "INP001",   # Docs folder does not need to be a package
+]
+"scripts/**" = [
+    "INP001",   # Scripts folder does not need to be a package
 ]
 "tests/**" = [
     "ARG005",   # Allow unused lambda arguments for mocking

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -81,7 +81,6 @@ docstring-code-format = true
 ignore = [
     "D100",   # Allow missing module docstring for brevity
     "D104",   # Allow missing package docstring for brevity
-    "D106",   # Allow missing nested class docstring (eg pydantic Config)
     "D203",   # Disallow blank line before class docstring (inverse of D211)
     "D213",   # Disallow multi-line docstring starting at second line (inverse of D212)
     "D406",   # Allow section name ending with newline (google style compat)

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -9,14 +9,14 @@ urls = { Repository = "https://github.com/robert-koch-institut/mex-{{ cookiecutt
 requires-python = ">=3.11,<3.13"
 dependencies = []
 optional-dependencies.dev = [
-    "ipdb>=0.13.13,<1",
-    "mypy>=1.11.2,<2",
-    "pytest-cov>=5.0.0,<6",
-    "pytest-random-order>=1.1.1,<2",
-    "pytest-xdist>=3.6.1,<4",
-    "pytest>=8.3.3,<9",
-    "ruff>=0.6.5,<1",
-    "sphinx>=8.0.2,<9",
+    "ipdb>=0.13,<1",
+    "mypy>=1,<2",
+    "pytest-cov>=5,<6",
+    "pytest-random-order>=1,<2",
+    "pytest-xdist>=3,<4",
+    "pytest>=8,<9",
+    "ruff>=0.6,<1",
+    "sphinx>=8,<9",
 ]
 
 [project.scripts]

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
 pdm==2.19.1
-pre-commit==4.0.0
+pre-commit==4.0.1
 wheel==0.44.0

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
 pdm==2.19.1
-pre-commit==3.8.0
+pre-commit==4.0.0
 wheel==0.44.0

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.19.1
+pdm==2.19.2
 pre-commit==4.0.1
 wheel==0.44.0

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
-mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.19.2
+mex-release==0.2.0
+pdm==2.19.3
 pre-commit==4.0.1
 wheel==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
 pdm==2.19.1
-pre-commit==4.0.0
+pre-commit==4.0.1
 wheel==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
 pdm==2.19.1
-pre-commit==3.8.0
+pre-commit==4.0.0
 wheel==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.19.1
+pdm==2.19.2
 pre-commit==4.0.1
 wheel==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
-mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.19.2
+mex-release==0.2.0
+pdm==2.19.3
 pre-commit==4.0.1
 wheel==0.44.0


### PR DESCRIPTION
# Changes
- use all ruff linter rules (with some opt-outs)
- install mex-release from pypi rather than github
- constrain dev-dependencies only to major/minor versions, to limit renovate noise
- title-case readme headings for a more professional look
