### PR TITLE
feature/mx-1622-add-changelog-entry-for-cruft-pull-requests

### DIFF
--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -79,6 +79,7 @@ jobs:
           git checkout -b cruft/cookiecutter-template-${template_ref}
           cruft update --skip-apply-ask
           printf '# Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
+          sed -i "0,/^### Changes/s|^### Changes.*|&\n- bumped cookiecutter template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n# Conflicts\n' >> .cruft-pr-body
           fi


### PR DESCRIPTION
### PR Context
As this is supposed to let cruft add an entry to the changelog in its PR through GitHub Actions when it updates and bumps to a new template version, it needs to tested accordingly. To test, use cruft to generate a test repo from the template, change something in the template to trigger cruft to update and push the test to GitHub. In the resulting open PR, the file changes tab should show the result.

Keep in mind that in the test repo generated from the template there are a few variables and secrets that the test repo won't have, so you may have to hardcode some arbitrary values into the workflow for testing.

Repo I used for testing: https://github.com/MikaMk4/mex-test

### Added

### Changes
cruft pull-requests now add an entry to the changelog

### Deprecated

### Removed

### Fixed

### Security
