### PR TITLE
feature/maint 20260416

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ downloads/
 eggs/
 lib/
 lib64/
-locked-requirements.txt
 MANIFEST
 parts/
 sdist/

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,19 @@ dmypy.json
 .history/
 *.code-workspace
 
+# Node and Angular
+.angular/
+.nodeenv
+.sass-cache/
+connect.lock
+coverage
+libpeerconnection.log
+node_modules
+npm-debug.log
+out-tsc
+testem.log
+typings
+
 # SQLite databases
 *.db
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,10 @@ dmypy.json
 
 # VisualStudioCode
 .vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
+!.vscode/tasks.json
 .history/
 *.code-workspace
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,18 @@ repos:
         name: json
         args: [--autofix, --indent=4, --no-ensure-ascii]
         exclude: cookiecutter.json
+      - id: check-yaml
+        name: yaml
+        exclude: mex-{{ cookiecutter.project_name }}/.github/workflows
       - id: end-of-file-fixer
         name: eof
       - id: trailing-whitespace
         name: whitespaces
       - id: fix-byte-order-marker
         name: byte-order
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.7
+    hooks:
+      - id: uv-lock
+        name: uv
+        args: [--check]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- remove uv-export from cve pipeline because trivy already supports uv.lock files
+
 ### Fixed
 
 - restore commit signing for renovate workflow (platformCommit only works for apps)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added angular specific config to ignore files
+
 ### Changes
 
+- moved docker image from locked-requirements.txt to two stage builds
+- run services as numeric users and skip user creation entirely
 - enable support for immutable github releases
 - use specific MEX_COOKIECUTTER_TOKEN for cookiecutter workflows
 - update uv and ruff dependencies

--- a/mex-{{ cookiecutter.project_name }}/.dockerignore
+++ b/mex-{{ cookiecutter.project_name }}/.dockerignore
@@ -113,6 +113,19 @@ dmypy.json
 .history/
 *.code-workspace
 
+# Node and Angular
+.angular/
+.nodeenv
+.sass-cache/
+connect.lock
+coverage
+libpeerconnection.log
+node_modules
+npm-debug.log
+out-tsc
+testem.log
+typings
+
 # SQLite databases
 *.db
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
@@ -59,11 +59,6 @@ jobs:
       - name: Install requirements
         run: make setup
 
-      - name: Export dependencies
-        run: |
-          mkdir --parents uv
-          uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
-
       - name: Run trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -98,28 +98,6 @@ jobs:
           {% raw %}ref: ${{ needs.release.outputs.tag }}{% endraw %}
           persist-credentials: false
 
-      - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        env:
-          cache-name: cache-requirements
-        with:
-          path: ~/.cache/pip
-          key: {% raw %}${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}{% endraw %}
-          restore-keys: |
-            {% raw %}${{ env.cache-name }}-{% endraw %}
-
-      - name: Setup python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.14
-
-      - name: Install requirements
-        run: make setup
-
-      - name: Generate locked requirements.txt
-        run: |
-          uv export --no-dev --output locked-requirements.txt --no-hashes
-
       - name: Login to container registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:

--- a/mex-{{ cookiecutter.project_name }}/.gitignore
+++ b/mex-{{ cookiecutter.project_name }}/.gitignore
@@ -20,7 +20,6 @@ downloads/
 eggs/
 lib/
 lib64/
-locked-requirements.txt
 MANIFEST
 parts/
 sdist/

--- a/mex-{{ cookiecutter.project_name }}/.gitignore
+++ b/mex-{{ cookiecutter.project_name }}/.gitignore
@@ -115,6 +115,19 @@ dmypy.json
 .history/
 *.code-workspace
 
+# Node and Angular
+.angular/
+.nodeenv
+.sass-cache/
+connect.lock
+coverage
+libpeerconnection.log
+node_modules
+npm-debug.log
+out-tsc
+testem.log
+typings
+
 # SQLite databases
 *.db
 

--- a/mex-{{ cookiecutter.project_name }}/.gitignore
+++ b/mex-{{ cookiecutter.project_name }}/.gitignore
@@ -112,6 +112,10 @@ dmypy.json
 
 # VisualStudioCode
 .vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
+!.vscode/tasks.json
 .history/
 *.code-workspace
 

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -4,8 +4,10 @@ repos:
     rev: v0.15.10
     hooks:
       - id: ruff-check
+        name: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     - id: mypy
       name: mypy
       entry: uv run dmypy run --timeout 7200 -- mex tests
-      files: ^(mex|tests)/
+      files: ^(mex|tests)/|pyproject\.toml$
       language: system
       pass_filenames: false
       types: [python]

--- a/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/mex-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.10
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -23,7 +23,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.2
+    rev: 0.11.7
     hooks:
       - id: uv-lock
         name: uv

--- a/mex-{{ cookiecutter.project_name }}/Dockerfile
+++ b/mex-{{ cookiecutter.project_name }}/Dockerfile
@@ -12,7 +12,7 @@ ENV PIP_PROGRESS_BAR=off
 COPY . .
 
 RUN pip install --no-cache-dir -r requirements.txt
-RUN uv export --no-dev | uv pip install --system --no-deps -r - .
+RUN uv export --no-dev --no-editable | uv pip install --system --no-deps -r -
 
 FROM python:3.14-slim
 

--- a/mex-{{ cookiecutter.project_name }}/Dockerfile
+++ b/mex-{{ cookiecutter.project_name }}/Dockerfile
@@ -1,6 +1,20 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14 AS base
+FROM python:3.14 AS builder
+
+WORKDIR /build
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=on
+ENV PIP_NO_INPUT=on
+ENV PIP_PREFER_BINARY=on
+ENV PIP_PROGRESS_BAR=off
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+RUN uv export --no-dev | uv pip install --system --no-deps -r - .
+
+FROM python:3.14-slim
 
 LABEL org.opencontainers.image.authors="mex@rki.de"
 LABEL org.opencontainers.image.description="{{ cookiecutter.short_summary }}"
@@ -11,28 +25,14 @@ LABEL org.opencontainers.image.vendor="robert-koch-institut"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONOPTIMIZE=1
 
-ENV PIP_DISABLE_PIP_VERSION_CHECK=on
-ENV PIP_NO_INPUT=on
-ENV PIP_PREFER_BINARY=on
-ENV PIP_PROGRESS_BAR=off
-
 ENV MEX_{{ cookiecutter.project_name|upper }}_HOST=0.0.0.0
 
 WORKDIR /app
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "10001" \
-    mex
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin/{{ cookiecutter.project_name }} /usr/local/bin/{{ cookiecutter.project_name }}
 
-COPY . .
-
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r locked-requirements.txt --no-deps
-
-USER mex
+USER 10001
 
 EXPOSE 8080
 

--- a/mex-{{ cookiecutter.project_name }}/Makefile
+++ b/mex-{{ cookiecutter.project_name }}/Makefile
@@ -43,7 +43,6 @@ wheel:
 image:
 	# build the docker image
 	@ echo building docker image mex-{{ cookiecutter.project_name }}:${LATEST}; \
-	export DOCKER_BUILDKIT=1; \
 	docker build \
 		--tag rki/mex-{{ cookiecutter.project_name }}:${LATEST} \
 		--tag rki/mex-{{ cookiecutter.project_name }}:latest .; \
@@ -53,15 +52,13 @@ run: image
 	@ echo running docker container mex-{{ cookiecutter.project_name }}:${LATEST}; \
 	docker run \
 		--env MEX_{{ cookiecutter.project_name|upper }}_HOST=0.0.0.0 \
-		--publish 8081:8081 \
+		--publish 8080:8080 \
 		rki/mex-{{ cookiecutter.project_name }}:${LATEST}; \
 
-start: image
+start:
 	# start the service using docker compose
 	@ echo start mex-{{ cookiecutter.project_name }}:${LATEST} with compose; \
-	export DOCKER_BUILDKIT=1; \
-	export COMPOSE_DOCKER_CLI_BUILD=1; \
-	docker compose up --remove-orphans; \
+	docker compose up --build --remove-orphans; \
 
 docs:
 	# use sphinx to auto-generate html docs from code

--- a/mex-{{ cookiecutter.project_name }}/compose.yaml
+++ b/mex-{{ cookiecutter.project_name }}/compose.yaml
@@ -6,9 +6,6 @@ services:
       - 8080:8080
     environment:
       - MEX_{{ cookiecutter.project_name|upper }}_HOST=0.0.0.0
-      - MEX_{{ cookiecutter.project_name|upper }}_PORT=8080
-    expose:
-      - 8080
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/_system/check" ]
       interval: 60s

--- a/mex-{{ cookiecutter.project_name }}/compose.yaml
+++ b/mex-{{ cookiecutter.project_name }}/compose.yaml
@@ -3,12 +3,12 @@ services:
     build:
       context: .
     ports:
-      - 8081:8081
+      - 8080:8080
     environment:
       - MEX_{{ cookiecutter.project_name|upper }}_HOST=0.0.0.0
       - MEX_{{ cookiecutter.project_name|upper }}_PORT=8080
     expose:
-      - 8081
+      - 8080
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/_system/check" ]
       interval: 60s

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.6
+uv==0.11.7
 pre-commit==4.5.1

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.2
-uv==0.11.2
+uv==0.11.6
 pre-commit==4.5.1

--- a/mex-{{ cookiecutter.project_name }}/requirements.txt
+++ b/mex-{{ cookiecutter.project_name }}/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.3.2
+mex-release==1.3.3
 uv==0.11.2
 pre-commit==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.6
+uv==0.11.7
 pre-commit==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.2
-uv==0.11.2
+uv==0.11.6
 pre-commit==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.3.2
+mex-release==1.3.3
 uv==0.11.2
 pre-commit==4.5.1


### PR DESCRIPTION
### Added

- added angular specific config to ignore files

### Changes

- moved docker image from locked-requirements.txt to two stage builds
- run services as numeric users and skip user creation entirely
- Update mypy hook to include pyproject.toml

### Removed

- remove uv-export from cve pipeline because trivy already supports uv.lock files

### What Else

- some smaller clean-ups and version updates
