### PR TITLE
feature/mx-2111-docker-image-signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added angular specific config to ignore files
+- add docker image signing steps on release
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable support for immutable github releases
 - use specific MEX_COOKIECUTTER_TOKEN for cookiecutter workflows
 - update uv and ruff dependencies
+- use docker-build-push instead of manual docker commands
 
 ### Deprecated
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -129,25 +129,24 @@ jobs:
       - name: Sign docker images
         env:
           {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
-          {% raw %}COSIGN_PRIVATE_KEY: ${{ secrets.MEX_SIGNING_KEY }}{% endraw %}
+          {% raw %}DIGEST: ${{ steps.push_step.outputs.digest }}{% endraw %}
+          {% raw %}BASE64_PRIV_KEY: ${{ secrets.MEX_SIGNING_KEY }}{% endraw %}
           COSIGN_PASSWORD: ""
-          {% raw %}COSIGN_PUBLIC_KEY: ${{ vars.MEX_SIGNING_PUB }}{% endraw %}
+          {% raw %}BASE64_PUB_KEY: ${{ vars.MEX_SIGNING_PUB }}{% endraw %}
           COSIGN_DOCKER_MEDIA_TYPES: 1
         run: |
-          echo "${COSIGN_PRIVATE_KEY}" > cosign.key
-          cosign sign -d --yes --registry-referrers-mode=legacy --key cosign.key ${IMAGE}@${{ steps.push_step.outputs.digest }}
+          {% raw -%}
+          # signing
+          export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
+          cosign sign -d --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
           echo "Signature generated successfully"
-          cosign tree ${IMAGE}@${{ steps.push_step.outputs.digest }}
-          rm cosign.key
 
-      - name: Verify upload
-        env:
-          {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
-          COSIGN_PUBLIC_KEY: ${{ vars.MEX_SIGNING_PUB }}
-        run: |
-          echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
-          cosign verify --key cosign.pub -d ${IMAGE}@${{ steps.push_step.outputs.digest }}
-          rm cosign.pub
+          # smoke test
+          echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
+          ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
+          cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"
+          rm temp_ssh_id.pub cosign.pub
+          {%- endraw %}
 
   distribute:
     runs-on: ubuntu-latest

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -141,12 +141,12 @@ jobs:
           # signing
           echo "Signing Image: ${IMAGE}@${DIGEST}"
           export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
-          cosign sign -d --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
+          cosign sign --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
           echo "Signature generated successfully"
 
           # smoke test
           echo "Verifying signature"
-          trap 'rm temp_ssh_id.pub cosign.pub' EXIT
+          trap 'rm -f temp_ssh_id.pub cosign.pub' EXIT
           echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
           ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
           cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -136,16 +136,21 @@ jobs:
           COSIGN_DOCKER_MEDIA_TYPES: 1
         run: |
           {% raw -%}
+          set -e # exit on first error
+
           # signing
+          echo "Signing Image: ${IMAGE}@${DIGEST}"
           export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
           cosign sign -d --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
           echo "Signature generated successfully"
 
           # smoke test
+          echo "Verifying signature"
+          trap 'rm temp_ssh_id.pub cosign.pub' EXIT
           echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
           ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
           cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"
-          rm temp_ssh_id.pub cosign.pub
+          echo "Signature verified successfully"
           {%- endraw %}
 
   distribute:

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -106,17 +106,48 @@ jobs:
           password: {% raw %}${{secrets.GITHUB_TOKEN}}{% endraw %}
 
       - name: Build, tag and push docker image
+        id: push_step
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v.7.1.0
         env:
           {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
           {% raw %}TAG: ${{ needs.release.outputs.tag }}{% endraw %}
+        with:
+          push: true
+          tags: |
+            {% raw -%}
+            ${IMAGE}:latest
+            ${IMAGE}:${{ github.sha }}
+            ${IMAGE}:${TAG}
+            {%- endraw %}
+          outputs: type=image,oci-mediatypes=true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign docker images
+        env:
+          {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
+          {% raw %}COSIGN_PRIVATE_KEY: ${{ secrets.MEX_SIGNING_KEY }}{% endraw %}
+          COSIGN_PASSWORD: ""
+          {% raw %}COSIGN_PUBLIC_KEY: ${{ vars.MEX_SIGNING_PUB }}{% endraw %}
+          COSIGN_DOCKER_MEDIA_TYPES: 1
         run: |
-          {% raw -%}
-          docker build . \
-          --tag ${IMAGE}:latest \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --tag ${IMAGE}:${TAG}
-          docker push --all-tags ${IMAGE}
-          {%- endraw %}
+          echo "${COSIGN_PRIVATE_KEY}" > cosign.key
+          cosign sign -d --yes --registry-referrers-mode=legacy --key cosign.key ${IMAGE}@${{ steps.push_step.outputs.digest }}
+          echo "Signature generated successfully"
+          cosign tree ${IMAGE}@${{ steps.push_step.outputs.digest }}
+          rm cosign.key
+
+      - name: Verify upload
+        env:
+          {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
+          COSIGN_PUBLIC_KEY: ${{ vars.MEX_SIGNING_PUB }}
+        run: |
+          echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
+          cosign verify --key cosign.pub -d ${IMAGE}@${{ steps.push_step.outputs.digest }}
+          rm cosign.pub
 
   distribute:
     runs-on: ubuntu-latest

--- a/mex-{{ cookiecutter.project_name }}/README.md
+++ b/mex-{{ cookiecutter.project_name }}/README.md
@@ -88,6 +88,23 @@ components of the MEx project are open-sourced under the same license as well.
 - run directly using docker `make run`
 - start with docker compose `make start`
 
+### Container verification
+
+Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
+
+Verification is handled by our deployment using the organization's public key.
+To verify an image manually:
+1. install `cosign` on your system
+2. obtain the organization's public key
+3. run the following command:
+   ```bash
+   cosign verify --key cosign.pub ghcr.io/robert-koch-institut/mex-{{ cookiecutter.project_name }}:<TAG>
+   ```
+
+To set up signing for a new project:
+1. ensure the organization-wide private key is available in a GitHub Secret named `MEX_SIGNING_KEY`
+2. ensure the organization-wide public key is available in a GitHub Variable named `MEX_SIGNING_PUB`
+
 ## Commands
 
 - run `uv run {command} --help` to print instructions


### PR DESCRIPTION
### PR Context

created a test repo from template to test out these changes. MEX_SIGNING_KEY (secret) and MEX_SIGNING_PUB (variable) need to be set in base64 encoding. existing public key is in ssh format and gets formatted to PEM/PKCS8 in action code because cosign requires that. 

### Added

- add docker image signing steps on release

### Changes

- use docker-build-push instead of manual docker commands