### PR TITLE
move to keyless signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added angular specific config to ignore files
-- add docker image signing steps on release
+- sign docker images using cosign (keyless)
 
 ### Changes
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -126,32 +126,11 @@ jobs:
         with:
           cosign-release: 'v2.4.1'
 
-      - name: Sign docker images
+      - name: Sign Docker image keyless
         env:
-          {% raw %}IMAGE: ghcr.io/${{ github.repository }}{% endraw %}
-          {% raw %}DIGEST: ${{ steps.push_step.outputs.digest }}{% endraw %}
-          {% raw %}BASE64_PRIV_KEY: ${{ secrets.MEX_SIGNING_KEY }}{% endraw %}
-          COSIGN_PASSWORD: ""
-          {% raw %}BASE64_PUB_KEY: ${{ vars.MEX_SIGNING_PUB }}{% endraw %}
-          COSIGN_DOCKER_MEDIA_TYPES: 1
+          {% raw %}IMAGE: ghcr.io/${{ github.repository }}:${{ steps.push_step.outputs.digest }}{% endraw %}
         run: |
-          {% raw -%}
-          set -e # exit on first error
-
-          # signing
-          echo "Signing Image: ${IMAGE}@${DIGEST}"
-          export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
-          cosign sign --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
-          echo "Signature generated successfully"
-
-          # smoke test
-          echo "Verifying signature"
-          trap 'rm -f temp_ssh_id.pub cosign.pub' EXIT
-          echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
-          ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
-          cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"
-          echo "Signature verified successfully"
-          {%- endraw %}
+          {% raw %}cosign sign --yes "$IMAGE"{% endraw %}
 
   distribute:
     runs-on: ubuntu-latest

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for cosign signing
 
     steps:
       - name: Checkout repo

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Sign Docker image keyless
         env:
-          {% raw %}IMAGE: ghcr.io/${{ github.repository }}:${{ steps.push_step.outputs.digest }}{% endraw %}
+          {% raw %}IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push_step.outputs.digest }}{% endraw %}
         run: |
           {% raw %}cosign sign --yes "$IMAGE"{% endraw %}
 

--- a/mex-{{ cookiecutter.project_name }}/README.md
+++ b/mex-{{ cookiecutter.project_name }}/README.md
@@ -92,18 +92,8 @@ components of the MEx project are open-sourced under the same license as well.
 
 Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
 
-Verification is handled by our deployment using the organization's public key.
 To verify an image manually:
-1. install `cosign` on your system
-2. obtain the organization's public key
-3. run the following command:
-   ```bash
-   cosign verify --key cosign.pub ghcr.io/robert-koch-institut/mex-{{ cookiecutter.project_name }}:<TAG>
-   ```
-
-To set up signing for a new project:
-1. ensure the organization-wide private key is available in a GitHub Secret named `MEX_SIGNING_KEY`
-2. ensure the organization-wide public key is available in a GitHub Variable named `MEX_SIGNING_PUB`
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/{{ cookiecutter.project_name }}" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/{{ cookiecutter.project_name }}:<tag>`
 
 ## Commands
 


### PR DESCRIPTION
### PR Context

fixing currently broken main branch by moving to keyless signing. managing the keys turned out to be quite complex with all the different key formats. tested in https://github.com/MikaMk4/mex-test
changing the changelog instead of appending as the "changes" before didn't work properly anyways.