### PR TITLE
 feature/maint-20260608

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use specific MEX_COOKIECUTTER_TOKEN for cookiecutter workflows
 - update uv and ruff dependencies
 - use docker-build-push instead of manual docker commands
+- renovate: update pre-commit hooks
+- renovate: create grouped PRs for non-major python and github action updates
+- renovate: widen lock file maintenance window so delayed workflow runs are more likely
+  within the window
 
 ### Deprecated
 

--- a/mex-{{ cookiecutter.project_name }}/renovate.json
+++ b/mex-{{ cookiecutter.project_name }}/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "before 4am on monday"
+            "on monday"
         ]
     },
     "packageRules": [
@@ -38,7 +38,30 @@
             "pinDigests": true
         },
         {
-            "description": "Immediately apply updates of mex packages",
+            "description": "Group all GitHub Actions updates into a single PR",
+            "groupName": "github-actions",
+            "matchManagers": [
+                "github-actions"
+            ]
+        },
+        {
+            "description": "Group all non-major Python updates into a single PR",
+            "groupName": "python non-major",
+            "matchCurrentVersion": "!/^0/",
+            "matchManagers": [
+                "pep621",
+                "pip_requirements"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "description": "Immediately apply updates of mex packages in dedicated PR",
+            "groupName": null,
             "matchPackageNames": [
                 "mex-*"
             ],
@@ -46,6 +69,9 @@
         }
     ],
     "prFooter": "",
+    "pre-commit": {
+        "enabled": true
+    },
     "vulnerabilityAlerts": {
         "enabled": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "before 4am on monday"
+            "on monday"
         ]
     },
     "packageRules": [
@@ -38,7 +38,30 @@
             "pinDigests": true
         },
         {
-            "description": "Immediately apply updates of mex packages",
+            "description": "Group all GitHub Actions updates into a single PR",
+            "groupName": "github-actions",
+            "matchManagers": [
+                "github-actions"
+            ]
+        },
+        {
+            "description": "Group all non-major Python updates into a single PR",
+            "groupName": "python non-major",
+            "matchCurrentVersion": "!/^0/",
+            "matchManagers": [
+                "pep621",
+                "pip_requirements"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "description": "Immediately apply updates of mex packages, in dedicated PR",
+            "groupName": null,
             "matchPackageNames": [
                 "mex-*"
             ],
@@ -46,6 +69,9 @@
         }
     ],
     "prFooter": "",
+    "pre-commit": {
+        "enabled": true
+    },
     "vulnerabilityAlerts": {
         "enabled": true
     }


### PR DESCRIPTION
### PR Context

To see the to-be-created PRs, search for `branches info extended` in [this renovate dry-run](https://github.com/robert-koch-institut/mex-backend/actions/runs/27141021958/job/80105960895).

### Changes
- renovate: update pre-commit hooks
- renovate: create grouped PRs for non-major python and github action updates
- renovate: widen lock file maintenance window so delayed workflow runs are more likely
  within the window
