### PR TITLE
feature/python_version-in-pyprojecttoml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `python_version = "3.14"` in pyprojecttoml
 - added angular specific config to ignore files
 - sign docker images using cosign (keyless)
 

--- a/mex-{{ cookiecutter.project_name }}/pyproject.toml
+++ b/mex-{{ cookiecutter.project_name }}/pyproject.toml
@@ -37,6 +37,7 @@ context = 5
 show_error_codes = true
 strict = true
 plugins = ["pydantic.mypy"]
+python_version = "3.14"
 
 [tool.pydantic-mypy]
 warn_untyped_fields = true


### PR DESCRIPTION
### PR Context
cutoffthetop suggested this change since i added it to mex.admin. Should be checked if this still valid with repos that uses more than one python version

### Added
`python_version = "3.14"` in pyprojecttoml
