### PR TITLE
feature/improve cruft workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- cookiecutter.yml workflow now tracks tagged releases instead of every main commit
 - moved docker image from locked-requirements.txt to two stage builds
 - run services as numeric users and skip user creation entirely
 - enable support for immutable github releases
@@ -33,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fix open pull request counting using gh cli json output
+- stop opening new cruft PRs when there already is one
 - restore commit signing for renovate workflow (platformCommit only works for apps)
 - stop using deprecated toml license link
 - fix open-code badge url

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix open pull request counting using gh cli json output
 - restore commit signing for renovate workflow (platformCommit only works for apps)
 - stop using deprecated toml license link
 - fix open-code badge url

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -86,6 +86,7 @@ jobs:
           sed -i "0,/^### Changes$/{/^### Changes$/{N;s|\n|\n\n- new template ${template_url}/releases/tag/${template_tag}|}}" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           fi
           find . -type f -name "*.rej" | while read -r line ; do
             printf '\n```diff\n' >> .cruft-pr-body
@@ -104,7 +105,7 @@ jobs:
         run: |
           {% raw -%}
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --set-upstream origin cruft/cookiecutter-template-${template_tag} --force --verbose
+          git push --set-upstream origin cruft/mex-template-${template_tag} --force --verbose
           {%- endraw %}
 
       - name: Create pull request
@@ -112,11 +113,17 @@ jobs:
         env:
           {% raw %}GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}{% endraw %}
           {% raw %}template_tag: ${{ steps.update.outputs.template_tag }}{% endraw %}
+          {% raw %}has_conflicts: ${{ steps.update.outputs.has_conflicts }}{% endraw %}
         run: |
           {% raw -%}
+          draft_flag=""
+          if [[ "${has_conflicts}" == "true" ]]; then
+            draft_flag="--draft"
+          fi
           gh pr create \
           --title "Bump cookiecutter template to ${template_tag}" \
           --body-file .cruft-pr-body \
           --label cruft \
-          --assignee ${MEX_BOT_USER}
+          --assignee ${MEX_BOT_USER} \
+          ${draft_flag}
           {%- endraw %}

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -72,7 +72,7 @@ jobs:
             echo template is up to date
             exit 0
           fi
-          if [[ $(gh pr list --label cruft | wc -c) -ne 0 ]]; then
+          if [[ -n "$(gh pr list --label cruft --state open --json number --jq '.[].number')" ]]; then
             echo already seeing pull request
             exit 0
           fi

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -80,10 +80,10 @@ jobs:
           fi
           echo "template_tag=${template_tag}" >> "$GITHUB_OUTPUT"
           git checkout main
-          git checkout -b cruft/cookiecutter-template-${template_tag}
+          git checkout -b cruft/mex-template-${template_tag}
           cruft update --checkout "${template_tag}" --skip-apply-ask
-          printf '### Changes\n\n- bumped cookiecutter template to %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
-          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/releases/tag/${template_tag}|" CHANGELOG.md
+          printf '### Changes\n\n- new template %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
+          sed -i "0,/^### Changes$/{/^### Changes$/{N;s|\n|\n\n- new template ${template_url}/releases/tag/${template_tag}|}}" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
           fi
@@ -93,7 +93,7 @@ jobs:
             printf '```\n' >> .cruft-pr-body
           done
           git add --all --verbose
-          git commit --message "Bump cookiecutter template to $template_tag" --verbose
+          git commit --message "Update mex-template to $template_tag" --verbose
           {%- endraw %}
 
       - name: Push branch

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cookiecutter.yml
@@ -68,7 +68,9 @@ jobs:
         id: update
         run: |
           {% raw -%}
-          if cruft check; then
+          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
+          template_tag=$(git ls-remote --tags --sort=-v:refname "${template_url}" | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')
+          if cruft check --checkout "${template_tag}"; then
             echo template is up to date
             exit 0
           fi
@@ -76,14 +78,12 @@ jobs:
             echo already seeing pull request
             exit 0
           fi
-          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
-          template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
-          echo "template_ref=${template_ref}" >> "$GITHUB_OUTPUT"
+          echo "template_tag=${template_tag}" >> "$GITHUB_OUTPUT"
           git checkout main
-          git checkout -b cruft/cookiecutter-template-${template_ref}
-          cruft update --skip-apply-ask
-          printf '### Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
-          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
+          git checkout -b cruft/cookiecutter-template-${template_tag}
+          cruft update --checkout "${template_tag}" --skip-apply-ask
+          printf '### Changes\n\n- bumped cookiecutter template to %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
+          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/releases/tag/${template_tag}|" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
           fi
@@ -93,29 +93,29 @@ jobs:
             printf '```\n' >> .cruft-pr-body
           done
           git add --all --verbose
-          git commit --message "Bump cookiecutter template to $template_ref" --verbose
+          git commit --message "Bump cookiecutter template to $template_tag" --verbose
           {%- endraw %}
 
       - name: Push branch
-        if: {% raw %}steps.update.outputs.template_ref{% endraw %}
+        if: {% raw %}steps.update.outputs.template_tag{% endraw %}
         env:
           {% raw %}GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}{% endraw %}
-          {% raw %}template_ref: ${{ steps.update.outputs.template_ref }}{% endraw %}
+          {% raw %}template_tag: ${{ steps.update.outputs.template_tag }}{% endraw %}
         run: |
           {% raw -%}
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
+          git push --set-upstream origin cruft/cookiecutter-template-${template_tag} --force --verbose
           {%- endraw %}
 
       - name: Create pull request
-        if: {% raw %}steps.update.outputs.template_ref{% endraw %}
+        if: {% raw %}steps.update.outputs.template_tag{% endraw %}
         env:
           {% raw %}GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}{% endraw %}
-          {% raw %}template_ref: ${{ steps.update.outputs.template_ref }}{% endraw %}
+          {% raw %}template_tag: ${{ steps.update.outputs.template_tag }}{% endraw %}
         run: |
           {% raw -%}
           gh pr create \
-          --title "Bump cookiecutter template to ${template_ref}" \
+          --title "Bump cookiecutter template to ${template_tag}" \
           --body-file .cruft-pr-body \
           --label cruft \
           --assignee ${MEX_BOT_USER}


### PR DESCRIPTION
### Changes

- cookiecutter.yml workflow now tracks tagged releases instead of every main commit,
  this way we dont need template-maint-PRs anymore and can just merge to main as usual and create a release when needed
 
### Fixed

- stop opening new cruft PRs when there already is one