### PR TITLE
feature/mx-2084-python-release-signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- sign python packages using sigstore (keyless)
+
 ### Changes
 
 ### Deprecated

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
     needs: release
     permissions:
       contents: write
+      id-token: write # Required for python release signing
 
     steps:
       - name: Checkout repo
@@ -167,12 +168,20 @@ jobs:
       - name: Install requirements
         run: make setup
 
-      - name: Build wheel and sdist distros and create a github release
+      - name: Build wheel and sdist distros
+        run: |
+          uv build --out-dir dist
+
+      - name: Sign Python release artifacts
+        uses: sigstore/gh-action-sigstore-python@5b79a39c381910c090341a2c9b0bf022c8b387e1 # v3.4.0
+        with:
+          inputs: ./dist/*
+
+      - name: Create a github release
         env:
-          {% raw %}GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         run: |
           {% raw -%}
-          uv build --out-dir dist
           gh release create ${{ needs.release.outputs.tag }} \
           --generate-notes --latest --verify-tag dist/*
           {%- endraw %}

--- a/mex-{{ cookiecutter.project_name }}/README.md
+++ b/mex-{{ cookiecutter.project_name }}/README.md
@@ -95,6 +95,30 @@ Images released to GHCR are signed using [cosign](https://github.com/sigstore/co
 To verify an image manually:
 `cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-{{ cookiecutter.project_name }}:<tag>`
 
+### Python release verification
+
+Python release artifacts (source distributions and wheels) published to GitHub Releases are signed keyless using [sigstore](https://github.com/sigstore/gh-action-sigstore-python).
+
+To verify a release artifact manually, download the artifact (e.g. `mex_{{ cookiecutter.project_name }}-<tag>-py3-none-any.whl`) and its Sigstore bundle (`mex_{{ cookiecutter.project_name }}-<tag>-py3-none-any.whl.sigstore.json`), then run either:
+
+**Using `sigstore`**:
+```bash
+sigstore verify identity \
+  --bundle <path-to-bundle> \
+  --cert-identity "https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml@refs/heads/main" \
+  --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
+  <path-to-artifact>
+```
+
+**Using `cosign`**:
+```bash
+cosign verify-blob \
+  --bundle <path-to-bundle> \
+  --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-{{ cookiecutter.project_name }}/.github/workflows/release.yml@refs/heads/main" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  <path-to-artifact>
+```
+
 ## Commands
 
 - run `uv run {command} --help` to print instructions


### PR DESCRIPTION
### PR Context
tried out in https://github.com/MikaMk4/mex-test
this only pushes signatures to github releases, NOT PyPI which is already automated with pypa/gh-action-pypi-publish action in respective repos (i.e. mex-common)

### Added

- sign python packages using sigstore (keyless)