### PR TITLE
feature/fix-ci-caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- cache pre-commit hook environments in the linting workflow
+
 ### Changes
 
 ### Deprecated
 
 ### Removed
 
+- drop the unused environment cache from the cve-scan workflow
+
 ### Fixed
+
+- point the environment cache at `~/.cache/uv` instead of `~/.cache/pip`
 
 ### Security
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/cve-scan.yml
@@ -41,16 +41,6 @@ jobs:
           restore-keys: |
             {% raw %}${{ env.cache-name }}-{% endraw %}
 
-      - name: Cache environment
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        env:
-          cache-name: cache-environment
-        with:
-          path: ~/.cache/pip
-          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('*.lock') }}{% endraw %}
-          restore-keys: |
-            {% raw %}${{ env.cache-name }}-{% endraw %}
-
       - name: Setup python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/documentation.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/documentation.yml
@@ -44,8 +44,8 @@ jobs:
         env:
           cache-name: cache-environment
         with:
-          path: ~/.cache/pip
-          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('*.lock') }}{% endraw %}
+          path: ~/.cache/uv
+          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('uv.lock') }}{% endraw %}
           restore-keys: |
             {% raw %}${{ env.cache-name }}-{% endraw %}
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/linting.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/linting.yml
@@ -53,8 +53,18 @@ jobs:
         env:
           cache-name: cache-environment
         with:
-          path: ~/.cache/pip
-          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('*.lock') }}{% endraw %}
+          path: ~/.cache/uv
+          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('uv.lock') }}{% endraw %}
+          restore-keys: |
+            {% raw %}${{ env.cache-name }}-{% endraw %}
+
+      - name: Cache pre-commit
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        env:
+          cache-name: cache-pre-commit
+        with:
+          path: ~/.cache/pre-commit
+          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}
           restore-keys: |
             {% raw %}${{ env.cache-name }}-{% endraw %}
 

--- a/mex-{{ cookiecutter.project_name }}/.github/workflows/testing.yml
+++ b/mex-{{ cookiecutter.project_name }}/.github/workflows/testing.yml
@@ -53,8 +53,8 @@ jobs:
         env:
           cache-name: cache-environment
         with:
-          path: ~/.cache/pip
-          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('*.lock') }}{% endraw %}
+          path: ~/.cache/uv
+          {% raw %}key: ${{ env.cache-name }}-${{ hashFiles('uv.lock') }}{% endraw %}
           restore-keys: |
             {% raw %}${{ env.cache-name }}-{% endraw %}
 


### PR DESCRIPTION
### Added

- cache pre-commit hook environments in the linting workflow

### Removed

- drop the unused environment cache from the cve-scan workflow

### Fixed

- point the environment cache at `~/.cache/uv` instead of `~/.cache/pip`

